### PR TITLE
7002 date format

### DIFF
--- a/pyopenfec/utils.py
+++ b/pyopenfec/utils.py
@@ -244,7 +244,7 @@ def default_empty_list(func):
     return inner
 
 
-def set_instance_attr(instance, attribute_name, value, date_fields, timezone=None):
+def set_instance_attr(instance, attribute_name, value, date_fields):
     """
     Set an attribute on an instance with special handling for date fields.
 
@@ -253,8 +253,6 @@ def set_instance_attr(instance, attribute_name, value, date_fields, timezone=Non
         attribute_name: The name of the attribute to set.
         value: The value to set for the attribute.
         date_fields: List of attribute names that represent date fields.
-        timezone: The timezone to use for creating a timezone-aware datetime object.
-                  If None, UTC timezone will be used.
 
     Returns:
         None


### PR DESCRIPTION
[#7002](https://github.com/NationalJournal/nj-cms/issues/7002)

Our `update_racetracker_finance_data` management command refreshes campaign finance data for election candidates in Race Tracker using data from the FEC. Starting on 7/31/23, we're seeing an error in Sentry related to data with an unexpected timestamp format. Please investigate and add graceful handling for the unexpected timestamp format.

Sentry error:
> ValueError _strptime in _strptime
> time data '2023-07-17T21:04:17' does not match format '%Y-%m-%dT%H:%M:%S+00:00'

## Reproducing the issue
Based on our Sentry logs, the error is cropping up every time `update_racetracker_finance_data` runs (it is scheduled to run every 4 hours). Make sure you have an up-to-date database snapshot so you can be confident your environment is trying to process finance data for the same elections as our production site.

Be aware, though, that the command is set to process only a limited number of elections each time it runs. That's done in order to limit the amount of time the command takes to run during each scheduled instance. Because of that, it's possible that you might have to try running the command multiple times to see the issue (though anecdotally it crops up on every run in production).

When this error occurs, the command stops partway.

## Testing
- run this command: `docker-compose exec backend pip install git+https://github.com/NationalJournal/pyopenfec@7002-date-format` to update` pyopenfec` package with the changes.
- run `docker-compose exec backend python manage.py update_racetracker_finance_data` few times and observe no errors.
- run `docker-compose exec backend python manage.py update_racetracker_finance_data  --year 2022` few times and observe no errors.
- run this command to return back to original pyopenfec: `docker-compose exec backend pip install git+https://github.com/NationalJournal/pyopenfec` .