### PR TITLE
update pytz to 2024.2

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [tool.poetry]
 name = "pyopenfec"
-version = "0.2.7"
+version = "0.2.8"
 description = "OpenFEC API Client"
 
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ maintainers = [
 [tool.poetry.dependencies]
 python = "^3.5"
 requests = "^2.22"
-pytz = "^2019.3"
+pytz = "^2024.2"
 
 [tool.poetry.dev-dependencies]
 pytest = "^3.0"

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 nose==1.3.7
 requests==2.22.0
-pytz==2019.3
+pytz==2024.2


### PR DESCRIPTION
## Ticket #7777

Vitaliy found that newer `croniter` versions pulled forward the version of `pytz`, which conflicts with `pyopenfec`'s preferred pinned version (`2019.3`):
https://github.com/NationalJournal/pyopenfec/blob/31cd391da47294795e111541c094062a8b7aac73/requirements.txt#L1-L3

It's possible that `pyopenfec` would work fine if we removed/changed the pinned version -- we have our own `pyopenfec` repo so we can edit the requirements. That could let us upgrade `croniter` to a newer version. After this batch of updates, Vitaliy may circle back to try that.

## Testing
- run `pip install pytz==2024.2`
- on local run `pip install git+https://github.com/NationalJournal/pyopenfec@7777-upgrade-pytz-lib`
- run `python manage.py quarterly_finance_report --year 2024 --quarter Q3 --body H` confirm that it runs without errors.
- run `pip install pytz==2019.3` return back to original version.